### PR TITLE
chore: configure Dependabot dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Europe/Paris"
+    open-pull-requests-limit: 5
+    assignees:
+      - "glandais"
+    commit-message:
+      prefix: "deps(maven)"
+      include: "scope"
+    labels:
+      - "dependencies"
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Summary

Adds a Dependabot configuration covering the following ecosystems:

- **maven** (`/`): weekly updates on Mondays at 09:00 Europe/Paris, grouped minor and patch updates, limit 5 PRs

Assignee set to `glandais`, commit messages prefixed with `deps(<ecosystem>)`, and all PRs labelled `dependencies`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)